### PR TITLE
Remove LGPL dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+.idea
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # WinRM for Go
 
+_Note_: This repository has been forked from `masterzen/winrm`. The only differences between this fork,
+and the upstream repository is the lack of LGPL dependencies. This is done by using
+`ChrisTrenkamp/goxpath` instead of `masterzen/xmlpath`, the latter of which is licensed under the LGPL license.
+
 _Note_: if you're looking for the `winrm` command-line tool, this has been splitted from this project and is available at [winrm-cli](https://github.com/masterzen/winrm-cli)
 
 This is a Go library to execute remote commands on Windows machines through

--- a/auth.go
+++ b/auth.go
@@ -10,7 +10,7 @@ import (
 	"github.com/masterzen/azure-sdk-for-go/core/http"
 	"github.com/masterzen/azure-sdk-for-go/core/tls"
 
-	"github.com/masterzen/winrm/soap"
+	"github.com/grubernaut/winrm/soap"
 )
 
 type ClientAuthRequest struct {

--- a/client.go
+++ b/client.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/masterzen/winrm/soap"
+	"github.com/grubernaut/winrm/soap"
 )
 
 // Client struct

--- a/client_test.go
+++ b/client_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/masterzen/winrm/soap"
+	"github.com/grubernaut/winrm/soap"
 
 	. "gopkg.in/check.v1"
 )

--- a/command_test.go
+++ b/command_test.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/masterzen/winrm/soap"
+	"github.com/grubernaut/winrm/soap"
 	. "gopkg.in/check.v1"
 )
 

--- a/http.go
+++ b/http.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/masterzen/winrm/soap"
+	"github.com/grubernaut/winrm/soap"
 )
 
 var soapXML = "application/soap+xml"

--- a/ntlm.go
+++ b/ntlm.go
@@ -1,7 +1,7 @@
 package winrm
 
 import (
-	ntlmssp "github.com/Azure/go-ntlmssp"
+	"github.com/Azure/go-ntlmssp"
 	"github.com/grubernaut/winrm/soap"
 )
 

--- a/ntlm.go
+++ b/ntlm.go
@@ -2,7 +2,7 @@ package winrm
 
 import (
 	ntlmssp "github.com/Azure/go-ntlmssp"
-	"github.com/masterzen/winrm/soap"
+	"github.com/grubernaut/winrm/soap"
 )
 
 // ClientNTLM provides a transport via NTLMv2

--- a/request.go
+++ b/request.go
@@ -8,8 +8,8 @@ import (
 )
 
 func genUUID() string {
-	uuid, _ := uuid.NewV4()
-	return "uuid:" + uuid.String()
+	id, _ := uuid.NewV4()
+	return "uuid:" + id.String()
 }
 
 func defaultHeaders(message *soap.SoapMessage, url string, params *Parameters) *soap.SoapHeader {
@@ -37,10 +37,10 @@ func NewOpenShellRequest(uri string, params *Parameters) *soap.SoapMessage {
 		AddOption(soap.NewHeaderOption("WINRS_CODEPAGE", "65001")).
 		Build()
 
-	body := message.CreateBodyElement("Shell", soap.NS_WIN_SHELL)
-	input := message.CreateElement(body, "InputStreams", soap.NS_WIN_SHELL)
+	body := message.CreateBodyElement("Shell", soap.DOM_NS_WIN_SHELL)
+	input := message.CreateElement(body, "InputStreams", soap.DOM_NS_WIN_SHELL)
 	input.SetContent("stdin")
-	output := message.CreateElement(body, "OutputStreams", soap.NS_WIN_SHELL)
+	output := message.CreateElement(body, "OutputStreams", soap.DOM_NS_WIN_SHELL)
 	output.SetContent("stdout stderr")
 
 	return message
@@ -77,16 +77,16 @@ func NewExecuteCommandRequest(uri, shellId, command string, arguments []string, 
 		AddOption(soap.NewHeaderOption("WINRS_SKIP_CMD_SHELL", "FALSE")).
 		Build()
 
-	body := message.CreateBodyElement("CommandLine", soap.NS_WIN_SHELL)
+	body := message.CreateBodyElement("CommandLine", soap.DOM_NS_WIN_SHELL)
 
 	// ensure special characters like & don't mangle the request XML
 	command = "<![CDATA[" + command + "]]>"
-	commandElement := message.CreateElement(body, "Command", soap.NS_WIN_SHELL)
+	commandElement := message.CreateElement(body, "Command", soap.DOM_NS_WIN_SHELL)
 	commandElement.SetContent(command)
 
 	for _, arg := range arguments {
 		arg = "<![CDATA[" + arg + "]]>"
-		argumentsElement := message.CreateElement(body, "Arguments", soap.NS_WIN_SHELL)
+		argumentsElement := message.CreateElement(body, "Arguments", soap.DOM_NS_WIN_SHELL)
 		argumentsElement.SetContent(arg)
 	}
 
@@ -104,8 +104,8 @@ func NewGetOutputRequest(uri, shellId, commandId, streams string, params *Parame
 		ShellId(shellId).
 		Build()
 
-	receive := message.CreateBodyElement("Receive", soap.NS_WIN_SHELL)
-	desiredStreams := message.CreateElement(receive, "DesiredStream", soap.NS_WIN_SHELL)
+	receive := message.CreateBodyElement("Receive", soap.DOM_NS_WIN_SHELL)
+	desiredStreams := message.CreateElement(receive, "DesiredStream", soap.DOM_NS_WIN_SHELL)
 	desiredStreams.SetAttr("CommandId", commandId)
 	desiredStreams.SetContent(streams)
 
@@ -126,8 +126,8 @@ func NewSendInputRequest(uri, shellId, commandId string, input []byte, params *P
 
 	content := base64.StdEncoding.EncodeToString(input)
 
-	send := message.CreateBodyElement("Send", soap.NS_WIN_SHELL)
-	streams := message.CreateElement(send, "Stream", soap.NS_WIN_SHELL)
+	send := message.CreateBodyElement("Send", soap.DOM_NS_WIN_SHELL)
+	streams := message.CreateElement(send, "Stream", soap.DOM_NS_WIN_SHELL)
 	streams.SetAttr("Name", "stdin")
 	streams.SetAttr("CommandId", commandId)
 	streams.SetContent(content)
@@ -146,9 +146,9 @@ func NewSignalRequest(uri string, shellId string, commandId string, params *Para
 		ShellId(shellId).
 		Build()
 
-	signal := message.CreateBodyElement("Signal", soap.NS_WIN_SHELL)
+	signal := message.CreateBodyElement("Signal", soap.DOM_NS_WIN_SHELL)
 	signal.SetAttr("CommandId", commandId)
-	code := message.CreateElement(signal, "Code", soap.NS_WIN_SHELL)
+	code := message.CreateElement(signal, "Code", soap.DOM_NS_WIN_SHELL)
 	code.SetContent("http://schemas.microsoft.com/wbem/wsman/1/windows/shell/signal/terminate")
 
 	return message

--- a/request.go
+++ b/request.go
@@ -3,7 +3,7 @@ package winrm
 import (
 	"encoding/base64"
 
-	"github.com/masterzen/winrm/soap"
+	"github.com/grubernaut/winrm/soap"
 	"github.com/nu7hatch/gouuid"
 )
 

--- a/request_test.go
+++ b/request_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grubernaut/winrm/soap"
 	"github.com/masterzen/simplexml/dom"
-	"github.com/masterzen/winrm/soap"
 	"github.com/masterzen/xmlpath"
 	. "gopkg.in/check.v1"
 )

--- a/request_test.go
+++ b/request_test.go
@@ -4,9 +4,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ChrisTrenkamp/goxpath"
+	"github.com/ChrisTrenkamp/goxpath/tree"
+	"github.com/ChrisTrenkamp/goxpath/tree/xmltree"
 	"github.com/grubernaut/winrm/soap"
 	"github.com/masterzen/simplexml/dom"
-	"github.com/masterzen/xmlpath"
 	. "gopkg.in/check.v1"
 )
 
@@ -93,19 +95,17 @@ func (s *WinRMSuite) TestSignalRequest(c *C) {
 }
 
 func assertXPath(c *C, doc *dom.Document, request string, expected string) {
-	root, path, err := parseXPath(doc, request)
+	nodes, err := parseXPath(doc, request)
 
 	if err != nil {
 		c.Fatalf("Xpath %s gives error %s", request, err)
 	}
 
-	ok := path.Exists(root)
-	c.Assert(ok, Equals, true)
+	c.Assert(len(nodes), Not(Equals), 0)
 
 	var foundValue string
-	iter := path.Iter(root)
-	for iter.Next() {
-		foundValue = iter.Node().String()
+	for _, i := range nodes {
+		foundValue = i.ResValue()
 		if foundValue == expected {
 			break
 		}
@@ -117,27 +117,26 @@ func assertXPath(c *C, doc *dom.Document, request string, expected string) {
 }
 
 func assertXPathNil(c *C, doc *dom.Document, request string) {
-	root, path, err := parseXPath(doc, request)
+	nodes, err := parseXPath(doc, request)
 
 	if err != nil {
 		c.Fatalf("Xpath %s gives error %s", request, err)
 	}
 
-	ok := path.Exists(root)
-	c.Assert(ok, Equals, false)
+	c.Assert(len(nodes), Equals, 0)
 }
 
-func parseXPath(doc *dom.Document, request string) (*xmlpath.Node, *xmlpath.Path, error) {
+func parseXPath(doc *dom.Document, request string) (tree.NodeSet, error) {
 	content := strings.NewReader(doc.String())
-	node, err := xmlpath.Parse(content)
+	body, err := xmltree.ParseXML(content)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	path, err := xmlpath.CompileWithNamespace(request, soap.GetAllNamespaces())
+	xpExec := goxpath.MustParse(request)
+	nodes, err := xpExec.ExecNode(body, soap.GetAllXPathNamespaces())
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-
-	return node, path, nil
+	return nodes, nil
 }

--- a/response.go
+++ b/response.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/masterzen/winrm/soap"
+	"github.com/grubernaut/winrm/soap"
 	"github.com/masterzen/xmlpath"
 )
 

--- a/response.go
+++ b/response.go
@@ -7,46 +7,45 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ChrisTrenkamp/goxpath"
+	"github.com/ChrisTrenkamp/goxpath/tree"
+	"github.com/ChrisTrenkamp/goxpath/tree/xmltree"
 	"github.com/grubernaut/winrm/soap"
-	"github.com/masterzen/xmlpath"
 )
 
-func first(node *xmlpath.Node, xpath string) (string, error) {
-	path, err := xmlpath.CompileWithNamespace(xpath, soap.GetAllNamespaces())
+func first(node tree.Node, xpath string) (string, error) {
+	nodes, err := xPath(node, xpath)
 	if err != nil {
 		return "", err
 	}
-	content, _ := path.String(node)
-	return content, nil
+	if len(nodes) < 1 {
+		return "", err
+	}
+	return nodes[0].ResValue(), nil
 }
 
-func any(node *xmlpath.Node, xpath string) (bool, error) {
-	path, err := xmlpath.CompileWithNamespace(xpath, soap.GetAllNamespaces())
+func any(node tree.Node, xpath string) (bool, error) {
+	nodes, err := xPath(node, xpath)
 	if err != nil {
 		return false, err
 	}
-
-	return path.Exists(node), nil
-
+	if len(nodes) > 0 {
+		return true, nil
+	}
+	return false, nil
 }
 
-func xpath(node *xmlpath.Node, xpath string) ([]xmlpath.Node, error) {
-	path, err := xmlpath.CompileWithNamespace(xpath, soap.GetAllNamespaces())
+func xPath(node tree.Node, xpath string) (tree.NodeSet, error) {
+	xpExec := goxpath.MustParse(xpath)
+	nodes, err := xpExec.ExecNode(node, soap.GetAllXPathNamespaces())
 	if err != nil {
 		return nil, err
 	}
-
-	nodes := make([]xmlpath.Node, 0, 1)
-	iter := path.Iter(node)
-	for iter.Next() {
-		nodes = append(nodes, *(iter.Node()))
-	}
-
 	return nodes, nil
 }
 
 func ParseOpenShellResponse(response string) (string, error) {
-	doc, err := xmlpath.Parse(strings.NewReader(response))
+	doc, err := xmltree.ParseXML(strings.NewReader(response))
 	if err != nil {
 		return "", err
 	}
@@ -54,7 +53,7 @@ func ParseOpenShellResponse(response string) (string, error) {
 }
 
 func ParseExecuteCommandResponse(response string) (string, error) {
-	doc, err := xmlpath.Parse(strings.NewReader(response))
+	doc, err := xmltree.ParseXML(strings.NewReader(response))
 	if err != nil {
 		return "", err
 	}
@@ -67,16 +66,16 @@ func ParseSlurpOutputErrResponse(response string, stdout, stderr io.Writer) (boo
 		exitCode int
 	)
 
-	doc, err := xmlpath.Parse(strings.NewReader(response))
+	doc, err := xmltree.ParseXML(strings.NewReader(response))
 
-	stdouts, _ := xpath(doc, "//rsp:Stream[@Name='stdout']")
+	stdouts, _ := xPath(doc, "//rsp:Stream[@Name='stdout']")
 	for _, node := range stdouts {
-		content, _ := base64.StdEncoding.DecodeString(node.String())
+		content, _ := base64.StdEncoding.DecodeString(node.ResValue())
 		stdout.Write(content)
 	}
-	stderrs, _ := xpath(doc, "//rsp:Stream[@Name='stderr']")
+	stderrs, _ := xPath(doc, "//rsp:Stream[@Name='stderr']")
 	for _, node := range stderrs {
-		content, _ := base64.StdEncoding.DecodeString(node.String())
+		content, _ := base64.StdEncoding.DecodeString(node.ResValue())
 		stderr.Write(content)
 	}
 
@@ -101,11 +100,11 @@ func ParseSlurpOutputResponse(response string, stream io.Writer, streamType stri
 		exitCode int
 	)
 
-	doc, err := xmlpath.Parse(strings.NewReader(response))
+	doc, err := xmltree.ParseXML(strings.NewReader(response))
 
-	nodes, _ := xpath(doc, fmt.Sprintf("//rsp:Stream[@Name='%s']", streamType))
+	nodes, _ := xPath(doc, fmt.Sprintf("//rsp:Stream[@Name='%s']", streamType))
 	for _, node := range nodes {
-		content, _ := base64.StdEncoding.DecodeString(node.String())
+		content, _ := base64.StdEncoding.DecodeString(node.ResValue())
 		stream.Write(content)
 	}
 

--- a/response_test.go
+++ b/response_test.go
@@ -2,6 +2,7 @@ package winrm
 
 import (
 	"bytes"
+
 	. "gopkg.in/check.v1"
 )
 

--- a/shell.go
+++ b/shell.go
@@ -27,10 +27,10 @@ func (s *Shell) Execute(command string, arguments ...string) (*Command, error) {
 }
 
 // Close will terminate this shell. No commands can be issued once the shell is closed.
-func (shell *Shell) Close() error {
-	request := NewDeleteShellRequest(shell.client.url, shell.id, &shell.client.Parameters)
+func (s *Shell) Close() error {
+	request := NewDeleteShellRequest(s.client.url, s.id, &s.client.Parameters)
 	defer request.Free()
 
-	_, err := shell.client.sendRequest(request)
+	_, err := s.client.sendRequest(request)
 	return err
 }

--- a/shell_test.go
+++ b/shell_test.go
@@ -1,7 +1,7 @@
 package winrm
 
 import (
-	"github.com/masterzen/winrm/soap"
+	"github.com/grubernaut/winrm/soap"
 	. "gopkg.in/check.v1"
 )
 

--- a/soap/header.go
+++ b/soap/header.go
@@ -1,8 +1,9 @@
 package soap
 
 import (
-	"github.com/masterzen/simplexml/dom"
 	"strconv"
+
+	"github.com/masterzen/simplexml/dom"
 )
 
 type HeaderOption struct {
@@ -99,62 +100,62 @@ func (self *SoapHeader) Options(options []HeaderOption) *SoapHeader {
 }
 
 func (self *SoapHeader) Build() *SoapMessage {
-	header := self.createElement(self.message.envelope, "Header", NS_SOAP_ENV)
+	header := self.createElement(self.message.envelope, "Header", DOM_NS_SOAP_ENV)
 
 	if self.to != "" {
-		to := self.createElement(header, "To", NS_ADDRESSING)
+		to := self.createElement(header, "To", DOM_NS_ADDRESSING)
 		to.SetContent(self.to)
 	}
 
 	if self.replyTo != "" {
-		replyTo := self.createElement(header, "ReplyTo", NS_ADDRESSING)
-		a := self.createMUElement(replyTo, "Address", NS_ADDRESSING, true)
+		replyTo := self.createElement(header, "ReplyTo", DOM_NS_ADDRESSING)
+		a := self.createMUElement(replyTo, "Address", DOM_NS_ADDRESSING, true)
 		a.SetContent(self.replyTo)
 	}
 
 	if self.maxEnvelopeSize != "" {
-		envelope := self.createMUElement(header, "MaxEnvelopeSize", NS_WSMAN_DMTF, true)
+		envelope := self.createMUElement(header, "MaxEnvelopeSize", DOM_NS_WSMAN_DMTF, true)
 		envelope.SetContent(self.maxEnvelopeSize)
 	}
 
 	if self.timeout != "" {
-		timeout := self.createElement(header, "OperationTimeout", NS_WSMAN_DMTF)
+		timeout := self.createElement(header, "OperationTimeout", DOM_NS_WSMAN_DMTF)
 		timeout.SetContent(self.timeout)
 	}
 
 	if self.id != "" {
-		id := self.createElement(header, "MessageID", NS_ADDRESSING)
+		id := self.createElement(header, "MessageID", DOM_NS_ADDRESSING)
 		id.SetContent(self.id)
 	}
 
 	if self.locale != "" {
-		locale := self.createMUElement(header, "Locale", NS_WSMAN_DMTF, false)
+		locale := self.createMUElement(header, "Locale", DOM_NS_WSMAN_DMTF, false)
 		locale.SetAttr("xml:lang", self.locale)
-		datalocale := self.createMUElement(header, "DataLocale", NS_WSMAN_MSFT, false)
+		datalocale := self.createMUElement(header, "DataLocale", DOM_NS_WSMAN_MSFT, false)
 		datalocale.SetAttr("xml:lang", self.locale)
 	}
 
 	if self.action != "" {
-		action := self.createMUElement(header, "Action", NS_ADDRESSING, true)
+		action := self.createMUElement(header, "Action", DOM_NS_ADDRESSING, true)
 		action.SetContent(self.action)
 	}
 
 	if self.shellId != "" {
-		selectorSet := self.createElement(header, "SelectorSet", NS_WSMAN_DMTF)
-		selector := self.createElement(selectorSet, "Selector", NS_WSMAN_DMTF)
+		selectorSet := self.createElement(header, "SelectorSet", DOM_NS_WSMAN_DMTF)
+		selector := self.createElement(selectorSet, "Selector", DOM_NS_WSMAN_DMTF)
 		selector.SetAttr("Name", "ShellId")
 		selector.SetContent(self.shellId)
 	}
 
 	if self.resourceURI != "" {
-		resource := self.createMUElement(header, "ResourceURI", NS_WSMAN_DMTF, true)
+		resource := self.createMUElement(header, "ResourceURI", DOM_NS_WSMAN_DMTF, true)
 		resource.SetContent(self.resourceURI)
 	}
 
 	if len(self.options) > 0 {
-		set := self.createElement(header, "OptionSet", NS_WSMAN_DMTF)
+		set := self.createElement(header, "OptionSet", DOM_NS_WSMAN_DMTF)
 		for _, option := range self.options {
-			e := self.createElement(set, "Option", NS_WSMAN_DMTF)
+			e := self.createElement(set, "Option", DOM_NS_WSMAN_DMTF)
 			e.SetAttr("Name", option.key)
 			e.SetContent(option.value)
 		}

--- a/soap/header_test.go
+++ b/soap/header_test.go
@@ -1,9 +1,10 @@
 package soap
 
 import (
+	"testing"
+
 	"github.com/masterzen/simplexml/dom"
 	. "gopkg.in/check.v1"
-	"testing"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -25,7 +26,7 @@ func initDocument() (h *SoapHeader) {
 	e := dom.CreateElement("Envelope")
 	doc.SetRoot(e)
 	AddUsualNamespaces(e)
-	NS_SOAP_ENV.SetTo(e)
+	DOM_NS_SOAP_ENV.SetTo(e)
 	h = &SoapHeader{message: &SoapMessage{document: doc, envelope: e}}
 	return
 }

--- a/soap/message.go
+++ b/soap/message.go
@@ -27,7 +27,7 @@ func NewMessage() (message *SoapMessage) {
 	e := dom.CreateElement("Envelope")
 	doc.SetRoot(e)
 	AddUsualNamespaces(e)
-	NS_SOAP_ENV.SetTo(e)
+	DOM_NS_SOAP_ENV.SetTo(e)
 
 	message = &SoapMessage{document: doc, envelope: e}
 	return
@@ -36,7 +36,7 @@ func NewMessage() (message *SoapMessage) {
 func (message *SoapMessage) NewBody() (body *dom.Element) {
 	body = dom.CreateElement("Body")
 	message.envelope.AddChild(body)
-	NS_SOAP_ENV.SetTo(body)
+	DOM_NS_SOAP_ENV.SetTo(body)
 	return
 }
 

--- a/soap/message_test.go
+++ b/soap/message_test.go
@@ -17,10 +17,10 @@ func (s *MySuite) TestNewMessage(c *C) {
 		AddOption(NewHeaderOption("WINRS_CODEPAGE", "65001")).
 		Build()
 
-	body := message.CreateBodyElement("Shell", NS_WIN_SHELL)
-	input := message.CreateElement(body, "InputStreams", NS_WIN_SHELL)
+	body := message.CreateBodyElement("Shell", DOM_NS_WIN_SHELL)
+	input := message.CreateElement(body, "InputStreams", DOM_NS_WIN_SHELL)
 	input.SetContent("stdin")
-	output := message.CreateElement(body, "OutputStreams", NS_WIN_SHELL)
+	output := message.CreateElement(body, "OutputStreams", DOM_NS_WIN_SHELL)
 	output.SetContent("stdout stderr")
 
 	expected := `<?xml version="1.0" encoding="utf-8" ?>

--- a/soap/namespaces.go
+++ b/soap/namespaces.go
@@ -1,24 +1,59 @@
 package soap
 
 import (
+	"github.com/ChrisTrenkamp/goxpath"
 	"github.com/masterzen/simplexml/dom"
-	"github.com/masterzen/xmlpath"
 )
 
+// Namespaces
+const (
+	NS_SOAP_ENV    = "http://www.w3.org/2003/05/soap-envelope"
+	NS_ADDRESSING  = "http://schemas.xmlsoap.org/ws/2004/08/addressing"
+	NS_CIMBINDING  = "http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"
+	NS_ENUM        = "http://schemas.xmlsoap.org/ws/2004/09/enumeration"
+	NS_TRANSFER    = "http://schemas.xmlsoap.org/ws/2004/09/transfer"
+	NS_WSMAN_DMTF  = "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"
+	NS_WSMAN_MSFT  = "http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd"
+	NS_SCHEMA_INST = "http://www.w3.org/2001/XMLSchema-instance"
+	NS_WIN_SHELL   = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell"
+	NS_WSMAN_FAULT = "http://schemas.microsoft.com/wbem/wsman/1/wsmanfault"
+)
+
+// Namespace Prefixes
+const (
+	NSP_SOAP_ENV    = "env"
+	NSP_ADDRESSING  = "a"
+	NSP_CIMBINDING  = "b"
+	NSP_ENUM        = "n"
+	NSP_TRANSFER    = "x"
+	NSP_WSMAN_DMTF  = "w"
+	NSP_WSMAN_MSFT  = "p"
+	NSP_SCHEMA_INST = "xsi"
+	NSP_WIN_SHELL   = "rsp"
+	NSP_WSMAN_FAULT = "f"
+)
+
+// DOM Namespaces
 var (
-	NS_SOAP_ENV    = dom.Namespace{"env", "http://www.w3.org/2003/05/soap-envelope"}
-	NS_ADDRESSING  = dom.Namespace{"a", "http://schemas.xmlsoap.org/ws/2004/08/addressing"}
-	NS_CIMBINDING  = dom.Namespace{"b", "http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"}
-	NS_ENUM        = dom.Namespace{"n", "http://schemas.xmlsoap.org/ws/2004/09/enumeration"}
-	NS_TRANSFER    = dom.Namespace{"x", "http://schemas.xmlsoap.org/ws/2004/09/transfer"}
-	NS_WSMAN_DMTF  = dom.Namespace{"w", "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"}
-	NS_WSMAN_MSFT  = dom.Namespace{"p", "http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd"}
-	NS_SCHEMA_INST = dom.Namespace{"xsi", "http://www.w3.org/2001/XMLSchema-instance"}
-	NS_WIN_SHELL   = dom.Namespace{"rsp", "http://schemas.microsoft.com/wbem/wsman/1/windows/shell"}
-	NS_WSMAN_FAULT = dom.Namespace{"f", "http://schemas.microsoft.com/wbem/wsman/1/wsmanfault"}
+	DOM_NS_SOAP_ENV    = dom.Namespace{"env", "http://www.w3.org/2003/05/soap-envelope"}
+	DOM_NS_ADDRESSING  = dom.Namespace{"a", "http://schemas.xmlsoap.org/ws/2004/08/addressing"}
+	DOM_NS_CIMBINDING  = dom.Namespace{"b", "http://schemas.dmtf.org/wbem/wsman/1/cimbinding.xsd"}
+	DOM_NS_ENUM        = dom.Namespace{"n", "http://schemas.xmlsoap.org/ws/2004/09/enumeration"}
+	DOM_NS_TRANSFER    = dom.Namespace{"x", "http://schemas.xmlsoap.org/ws/2004/09/transfer"}
+	DOM_NS_WSMAN_DMTF  = dom.Namespace{"w", "http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd"}
+	DOM_NS_WSMAN_MSFT  = dom.Namespace{"p", "http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd"}
+	DOM_NS_SCHEMA_INST = dom.Namespace{"xsi", "http://www.w3.org/2001/XMLSchema-instance"}
+	DOM_NS_WIN_SHELL   = dom.Namespace{"rsp", "http://schemas.microsoft.com/wbem/wsman/1/windows/shell"}
+	DOM_NS_WSMAN_FAULT = dom.Namespace{"f", "http://schemas.microsoft.com/wbem/wsman/1/wsmanfault"}
 )
 
-var MostUsed = [...]dom.Namespace{NS_SOAP_ENV, NS_ADDRESSING, NS_WIN_SHELL, NS_WSMAN_DMTF, NS_WSMAN_MSFT}
+var MostUsed = [...]dom.Namespace{
+	DOM_NS_SOAP_ENV,
+	DOM_NS_ADDRESSING,
+	DOM_NS_WIN_SHELL,
+	DOM_NS_WSMAN_DMTF,
+	DOM_NS_WSMAN_MSFT,
+}
 
 func AddUsualNamespaces(node *dom.Element) {
 	for _, ns := range MostUsed {
@@ -26,12 +61,21 @@ func AddUsualNamespaces(node *dom.Element) {
 	}
 }
 
-func GetAllNamespaces() []xmlpath.Namespace {
-	var ns = []dom.Namespace{NS_WIN_SHELL, NS_ADDRESSING, NS_WSMAN_DMTF, NS_WSMAN_MSFT, NS_SOAP_ENV}
-
-	var xmlpathNs = make([]xmlpath.Namespace, 0, 4)
-	for _, namespace := range ns {
-		xmlpathNs = append(xmlpathNs, xmlpath.Namespace{Prefix: namespace.Prefix, Uri: namespace.Uri})
+func GetAllXPathNamespaces() func(o *goxpath.Opts) {
+	ns := map[string]string{
+		NSP_SOAP_ENV:    NS_SOAP_ENV,
+		NSP_ADDRESSING:  NS_ADDRESSING,
+		NSP_CIMBINDING:  NS_CIMBINDING,
+		NSP_ENUM:        NS_ENUM,
+		NSP_TRANSFER:    NS_TRANSFER,
+		NSP_WSMAN_DMTF:  NS_WSMAN_DMTF,
+		NSP_WSMAN_MSFT:  NS_WSMAN_MSFT,
+		NSP_SCHEMA_INST: NS_SCHEMA_INST,
+		NSP_WIN_SHELL:   NS_WIN_SHELL,
+		NSP_WSMAN_FAULT: NS_WSMAN_FAULT,
 	}
-	return xmlpathNs
+
+	return func(o *goxpath.Opts) {
+		o.NS = ns
+	}
 }

--- a/soap/namespaces_test.go
+++ b/soap/namespaces_test.go
@@ -1,8 +1,9 @@
 package soap
 
 import (
-	"github.com/masterzen/simplexml/dom"
 	"testing"
+
+	"github.com/masterzen/simplexml/dom"
 )
 
 func TestAddUsualNamespaces(t *testing.T) {
@@ -22,14 +23,13 @@ func TestAddUsualNamespaces(t *testing.T) {
 			t.Errorf("Test failed - Namespace %v not found", ns)
 		}
 	}
-
 }
 
 func TestSetTo(t *testing.T) {
 	doc := dom.CreateDocument()
 	root := dom.CreateElement("root")
 	doc.SetRoot(root)
-	NS_SOAP_ENV.SetTo(root)
+	DOM_NS_SOAP_ENV.SetTo(root)
 
 	if root.String() != `<env:root xmlns:env="http://www.w3.org/2003/05/soap-envelope"/>` {
 		t.Errorf("Test failed - root has not the correct NS: %s", root.String())


### PR DESCRIPTION
Replaces the LGPL dependency `masterzen/xmlpath` with `ChrisTrenkamp/goxpath`,
which is under the `MIT` license.

Underlying API's should be the same, and there aren't any expected
breaking changes to any public functions exposed via this WinRM library.

This change is solely to modify dependencies away from an LGPL license.

```
$ make test
==> Installing dependencies
==> Testing...
go test ./...
ok      github.com/grubernaut/winrm     5.050s
ok      github.com/grubernaut/winrm/soap        0.003s
```